### PR TITLE
Added hyperlink to go to Computer Science & Engineering Labs which was broken (Issue #92)

### DIFF
--- a/src/lab/index.html
+++ b/src/lab/index.html
@@ -88,7 +88,7 @@
 			
 			<!-- =================================================================================================================================== -->
 			<div class="container-fluid"  style="margin-left: 35px; margin-right: 35px;">
-				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://vlabs.ac.in/computer-science-and-engineering-labs.html" class="sidebar-a" >Computer Science & Engineering</a><br/></h2>
+				<h2 class="text-h2-lightblue" style=" margin-bottom: 20px; margin-top: 10px; "><a href="http://vlab.co.in/broad-area-computer-science-and-engineering" class="sidebar-a" >Computer Science & Engineering</a><br/></h2>
 					
 					<div class="row">
 						<div class="col-md-2 sidebar-col-2">


### PR DESCRIPTION
The hyperlink to Computer Science & Engineering was broken from the index.html page of the lab. This has been fixed.