### PR TITLE
Fixed broken link to vlabs-dev in FAQ page (issue #121)

### DIFF
--- a/src/lab/faq.html
+++ b/src/lab/faq.html
@@ -173,7 +173,7 @@ Chrome <br> 2) Plugins: Flash, Java 1.6 version, and IcedTea<br> 3) JavaScript s
 <p class="text-h3-darkblue-bold">Q20. How does one can contribute to Virtual-Labs?</p>
 <p> vlabs-dev is the main portal for Virtual Labs Development. Please visit
   the contributing section
-  of <a href="http://vlabs-dev.vlabs.ac.in/community/contributing.html"
+  of <a href="http://vlabs.iitb.ac.in/vlabs-dev/"
   target="_blank">VLABS DEV</a> page.
 							
 							</div>


### PR DESCRIPTION
The broken link to vlabs-dev in the FAQ page has been fixed to the link of vlabs-dev on the homepage.